### PR TITLE
new always thread

### DIFF
--- a/CDEvents.h
+++ b/CDEvents.h
@@ -6,10 +6,10 @@
 //// without written permission.                                        ////
 ////                                                                    ////
 //// Author: Dario Cortese                                              ////
-//// Client: I.S.A. srl                                                 ////
+//// Client: Mongoose srl (Mariano Cerbone)                             ////
 //// User: Dario Cortese                                                ////
 //// Created on 27/01/2012                                              ////
-//// Modify on 18/04/2013 to adapt at CCS compiler                      ////
+//// Modify on 28/02/2019 to be adapted at CCS compiler                 ////
 //// File: cdevents.h                                                   ////
 //// Description:                                                       ////
 ////    This file has the functions prototypes and data definitions     ////
@@ -24,79 +24,147 @@
 
 #include "CD_types.h"
 
+//if following is defined then cdevent_t has the ptrParam and is possible to use also
+// cdeventSetParamPointer and cdeventGetParamPointer to pass information with the event
+//but this use resource so is possible to disable
+//#define CDEVENT_USE_PTRPARAM
 
+#ifdef CDEVENT_USE_PTRPARAM
 typedef struct cdevent_t_tag{
    sint_t Enabled;   //!< indicates if true that the event is usable (if false and active=true however the isActive function return false) 
-   sint_t Active;      //!< indicates if the event is happened, this flag must be resetted (=false) by the event consumer/manager
-   sint_t Id;         //!< optional, indicates a number that identify the event of the same type (used in events array)
-   void* ptrParam;   //!< optiona, is a pointer to static memory that point to a primitive data or struct (user data) that must be used to pass a parameter to event consumer/manager
+//   sint_t Active;      //!< indicates if the event is happened, this flag must be resetted (=false) by the event consumer/manager
+//   sint_t Id;         //!< optional, indicates a number that identify the event of the same type (used in events array)
+   uint_t Counter;      //!< indicates the number of times that event is happened before kill him (when killed this counter resets)   
+   void* ptrParam;   //!< optional, is a pointer to static memory that point to a primitive data or struct (user data) that must be used to pass a parameter to event consumer/manager
+}cdevent_t;
+#else //CDEVENT_USE_PTRPARAM
+typedef struct cdevent_t_tag{
+   sint_t Enabled;   //!< indicates if true that the event is usable (if false and active=true however the isActive function return false) 
+   uint_t Counter;      //!< indicates the number of times that event is happened before kill him (when killed this counter resets)   
 }cdevent_t;
 
+#endif //ELSE CDEVENT_USE_PTRPARAM
 
 
-/*! \def cdeventInit( XX,YY)
+///*! \def cdeventInit( XyX,YxY)
+//   inits the event, this means that is enabled but not activated and the id is set to pEvtId with param pointer to null (0); y is the id number (int) for this event
+//   \n param XyX is the event structure
+//   \n param YxY is the event id number; 
+//   \todo test it   
+//*/
+//#define cdeventInit(XyX,YxY)  XyX.Enabled= TRUE ; XyX.Active= FALSE ; XyX.Id=( YxY ); XyX.ptrParam=0
+
+#ifdef CDEVENT_USE_PTRPARAM
+
+/*! \def cdeventInit( XyX)
    inits the event, this means that is enabled but not activated and the id is set to pEvtId with param pointer to null (0); y is the id number (int) for this event
-   \n param XX is the event structure
-   \n param YY is the event id number; 
+   \n param XyX is the event structure
    \todo test it   
 */
-#define cdeventInit(XX,YY)  XX.Enabled= TRUE ; XX.Active= FALSE ; XX.Id=( YY ); XX.ptrParam=0
+#define cdeventInit(XyX)  XyX.Enabled= TRUE ; XyX.Counter=0 ; XyX.ptrParam=0
+//#define cdeventInit(XyX)  XyX.Enabled= TRUE ; XyX.Active= FALSE ; XyX.Counter=0 ; XyX.ptrParam=0
 
-/*! \def cdeventGenerate(XX)
-   activate the event, pratically set Active at true, but doesn't change Enabled, so if enabled is false then the event remains inactive untile Enabled became true 
-   \n param XX is the event structure
+#else //CDEVENT_USE_PTRPARAM
+
+/*! \def cdeventInit( XyX)
+   inits the event, this means that is enabled but not activated and the id is set to pEvtId with param pointer to null (0); y is the id number (int) for this event
+   \n param XyX is the event structure
    \todo test it   
 */
-#define cdeventGenerate(XX) XX.Active= TRUE
+#define cdeventInit(XyX)  XyX.Enabled= TRUE ; XyX.Counter=0
 
-/*! \def cdeventKill(XX)
-   deactivate the event, pratically set Active at false 
-   \n param XX is the event structure
+#endif //else CDEVENT_USE_PTRPARAM
+
+
+/*! \def cdeventGenerate(XyX)
+   activate the event, pratically increment counter, but doesn't change Enabled, so if enabled is false then the event remains inactive untile Enabled became true 
+   \n param XyX is the event structure
    \todo test it   
 */
-#define cdeventKill(XX) XX.Active= FALSE
+#define cdeventGenerate(XyX) if( XyX.Enabled ){ if( XyX.Counter < 255 ) XyX.Counter++; } 
+//#define cdeventGenerate(XyX) if( XyX.Enabled ){ XyX.Active= TRUE ; if( XyX.Counter < 255 ) XyX.Counter++; } 
+//#define cdeventGenerate(XyX) XyX.Active= TRUE
 
-/*! \def cdeventEnable(XX)
+
+/*! \def cdeventKill(XyX)
+   deactivate the event, pratically set reduce the counter 
+   \n param XyX is the event structure
+   \todo test it   
+*/
+#define cdeventKill(XyX) if( XyX.Counter > 0 ) { XyX.Counter-- ;} 
+//#define cdeventKill(XyX) XyX.Active= FALSE; XyX.Counter=0
+//#define cdeventKill(XyX) XyX.Active= FALSE
+
+/*! \def cdeventDestroy(XyX)
+   deactivate the event, pratically set counter to 0
+   \n param XyX is the event structure
+   \todo test it   
+*/
+#define cdeventDestry(XyX) XyX.Counter = 0 
+
+/*! \def cdeventEnable(XyX)
    Enable the event, pratically set Enable at true, but doesn't change Active, if Active is true the event became immediately active, otherwise the event remains inactive untile Active became true 
-   \n param XX is the event structure
+   \n param XyX is the event structure
    \todo test it   
 */
-#define cdeventEnable(XX) XX.Enabled= TRUE
+#define cdeventEnable(XyX) XyX.Enabled= TRUE
 
-/*! \def cdeventDisable(XX)
+/*! \def cdeventDisable(XyX)
    Disable the event, pratically set Enable at false, but doesn't change Active, if Active is true the event became immediately inactive, until it return enabled
-   \n param XX is the event structure
+   \n param XyX is the event structure
    \todo test it   
 */
-#define cdeventDisable(XX) XX.Enabled= FALSE
+#define cdeventDisable(XyX) XyX.Enabled= FALSE
 
-/*! \def cdeventIsActive(XX)
-   checks if event is active (was generated); the event must be Enabled to be  also active. It will be active, if was generated, when will return Enabled
-   \n param XX is the event structure
+/*! \def cdeventIsOccurred(XyX)
+   checks if event is occurred (was generated); the event must be Enabled to happen. It will be active, if was generated, when will return TRUE
+   \n param XyX is the event structure
+   \return TRUE if event occurred, FALSE if not
+*/
+#define cdeventIsOccurred(XyX) ( XyX.Counter > 0 )   
+#define cdeventIsActive(XyX) ( XyX.Counter > 0 )   
+//#define cdeventIsOccurred(XyX) (XyX.Active)   
+//#define cdeventIsActive(XyX) (XyX.Active)   
+//#define cdeventIsActive(XyX) ((XyX.Enabled) && (XyX.Active))   
+
+/*! \def cdeventIsNotOccurred(XyX)
+   checks if event is not occurred (not generated, previously killed); It will be active, if was generated, when will return TRUE
+   \n param XyX is the event structure
+   \return TRUE if event occurred, FALSE if not
+*/
+#define cdeventIsNotOccurred(XyX) ( XyX.Counter == 0 )   
+#define cdeventIsInactive(XyX) ( XyX.Counter == 0 )   
+
+///*! \def cdeventGetId(XyX)
+//   read the id of the event; XyX is the event_struct variable 
+//   \n param XyX is the event structure
+//   \todo test it   
+//*/
+//#define cdeventGetId(XyX) (XyX.Id)
+/*! \def cdeventGetCounter(XyX)
+   return the Number of times (max 127)that is happened the event when enabled and before to be killed; XyX is the event_struct variable 
+   \n param XyX is the event structure
    \todo test it   
 */
-#define cdeventIsActive(XX) ((XX.Enabled) && (XX.Active))   
+#define cdeventGetCounter(XyX) (XyX.Counter)
 
-/*! \def cdeventGetId(XX)
-   read the id of the event; XX is the event_struct variable 
-   \n param XX is the event structure
+
+#ifdef CDEVENT_USE_PTRPARAM
+/*! \def cdeventSetParamPointer(XyX,YxY)
+   set the ptrParam of event to YxY that must be a pointer; XyX is the event_struct variable 
+   \n param XyX is the event structure
+   \n param YxY is the memory pointer to param data; the structure of data depends by event and must be knowed by event user 
    \todo test it   
 */
-#define cdeventGetId(XX) (XX.Id)
+#define cdeventSetParamPointer(XyX,YxY) XyX.ptrParam=(void*)(YxY)
 
-/*! \def cdeventSetParamPointer(XX,YY)
-   set the ptrParam of event to YY that must be a pointer; XX is the event_struct variable 
-   \n param XX is the event structure
-   \n param YY is the memory pointer to param data; the structure of data depends by event and must be knowed by event user 
-   \todo test it   
-*/
-#define cdeventSetParamPointer(XX,YY) XX.ptrParam=(void*)(YY)
-
-/*! \def cdeventGetParamPointer(XX)
+/*! \def cdeventGetParamPointer(XyX)
 	get the ptrParam of event, return a void pointer; xx is the event_struct variable 
-   \n param XX is the event structure
+   \n param XyX is the event structure
    \todo test it   
 */
-#define cdeventGetParamPointer(XX) (XX.ptrParam)
+#define cdeventGetParamPointer(XyX) (XyX.ptrParam)
+#endif //CDEVENT_USE_PTRPARAM
+
 
 #endif //__CDEVENTS_H_

--- a/CDMessage.c
+++ b/CDMessage.c
@@ -6,8 +6,9 @@
 //// without written permission.                                        ////
 ////                                                                    ////
 //// Author: Dario Cortese                                              ////
-//// Client: myself                                                     ////
+//// Client: Mongoose srl (Mariano Cerbone)                             ////
 //// Created on 10/08/2012                                              ////
+//// Modify on 12/05/2018 to be adapted at XC8 compiler                 ////
 //// File: cdmessage.c                                                  ////
 //// Description:                                                       ////
 //// THIS FILE HAVE ALL IMPLEMENTATION OF FUNCTION USED FOR CDMESSAGE   ////
@@ -21,8 +22,11 @@
 
 
 //is the system array that stores the cdmessage structure used to manage messages
+#ifdef PLATFORM_BLACKFIN
+section("L1_data_b")  cdmessageStruct cdmessagesSystemArray[CDTHREAD_MAX_NUM_MESSAGES];
+#else
 cdmessageStruct cdmessagesSystemArray[CDTHREAD_MAX_NUM_MESSAGES];
-
+#endif
 //to avoid array splitting located at the start of BANK2 gen Pourpose area (80 bytes), avery message struct is 8 bytes, so 10 messages max
 //#locate cdmessagesSystemArray=0x124
 
@@ -39,12 +43,12 @@ cdmessageStruct cdmessagesSystemArray[CDTHREAD_MAX_NUM_MESSAGES];
 void cdmessage_initAll(void){
    cdMessageID_t idx;
    for(idx=0; idx < CDTHREAD_MAX_NUM_MESSAGES; idx++){
-      cdmessagesSystemArray[idx].cdthID=CDTHREADID_ERROR;      //free/available position, so not associated
-      cdmessagesSystemArray[idx].State=CDMESSAGESTATE_DELETED;//free/available position
-      //cdmessagesSystemArray[idx].ptrData = CDMESSAGEDATA_NODATA;   //no data associated
-      cdmessagesSystemArray[idx].Data = 0;   //no data available
-      cdmessagesSystemArray[idx].Info = 0;   //default value
-      cdmessagesSystemArray[idx].NextMsgID = CDMESSAGEID_ERROR;   //no next message   
+      cdmessagesSystemArray[(uint16_t)idx].cdthID=CDTHREADID_ERROR;      //free/available position, so not associated
+      cdmessagesSystemArray[(uint16_t)idx].State=CDMESSAGESTATE_DELETED;//free/available position
+      //cdmessagesSystemArray[(unsigned)idx].ptrData = CDMESSAGEDATA_NODATAPTR;   //no data associated
+      cdmessagesSystemArray[(uint16_t)idx].Data = 0;   //no data available
+      cdmessagesSystemArray[(uint16_t)idx].Info = 0;   //default value
+      cdmessagesSystemArray[(uint16_t)idx].NextMsgID = CDMESSAGEID_ERROR;   //no next message   
    }
 }
 
@@ -62,7 +66,7 @@ void cdmessage_initAll(void){
 */
 cdMessageID_t cdmessage_getFreeID(void){
    //uses static id so next time that a new message position is requested, start from a new position and avoid to 
-   //reuse position until array end is reached
+   //reuse position until array end is reached  
     cdThreadID_t starting_idx;
    static cdMessageID_t idx=0;
       //because cdThreadID_t now is signed, then this test must be performed to avoid error
@@ -70,7 +74,7 @@ cdMessageID_t cdmessage_getFreeID(void){
    if(idx >= CDTHREAD_MAX_NUM_MESSAGES) idx=0;
    starting_idx = idx;
    for(; idx < CDTHREAD_MAX_NUM_MESSAGES; idx++){
-      if (cdmessagesSystemArray[idx].State==CDMESSAGESTATE_DELETED){
+      if (cdmessagesSystemArray[(uint16_t)idx].State==CDMESSAGESTATE_DELETED){
          idx++;   //so next time that reenter use next new position
          //return (idx+1); ////ID is always the real array index +1, because id=0 means unused/deleted
          return idx;
@@ -79,15 +83,14 @@ cdMessageID_t cdmessage_getFreeID(void){
    //if first search, searching from last idx has no positive result (otherwire exit with return and doesn't arrives here)
    // then execute a second search starting from 0
    if (starting_idx!= 0){ //as is starting_idx>0 but more fast
-       for(idx=0; idx < CDTHREAD_MAX_NUM_MESSAGES; idx++){
-          if (cdmessagesSystemArray[idx].State==CDMESSAGESTATE_DELETED){
-             idx++;   //so next time that reenter use next new position
-             //return (idx+1); ////ID is always the real array index +1, because id=0 means unused/deleted
-             return idx;
-          }
-       }
+   for(idx=0; idx < CDTHREAD_MAX_NUM_MESSAGES; idx++){
+      if (cdmessagesSystemArray[(uint16_t)idx].State==CDMESSAGESTATE_DELETED){
+         idx++;   //so next time that reenter use next new position
+         //return (idx+1); ////ID is always the real array index +1, because id=0 means unused/deleted
+         return idx;
+      }
+   }
    } //end if (starting_idx>0)
-
    //if also second search has no positive result then this means that there isn't available message id free, at compiling time
    // increments CDTHREAD_MAX_NUM_MESSAGES define, or check if some message is many time allocated without remove   
    return CDMESSAGEID_ERROR; //means no available messages
@@ -109,7 +112,7 @@ cdMessageID_t cdmessage_getArrayIdxFromID(cdMessageID_t pMsgId){
    cdMessageID_t realidx;
    if(!cdmessage_checkValidID( pMsgId)) return -1;
    //convert pMsgId in real index for cdmessagesSystemArray
-   realidx = (int)pMsgId;
+   realidx = (sint_t)pMsgId;
    realidx--;
    return realidx;
 }
@@ -129,7 +132,7 @@ cdMessageID_t cdmessage_getArrayIdxFromID(cdMessageID_t pMsgId){
    \param pInfoVal is an integer that inform receiver what is the message (is a number and values must be user defined)
    \param pData is the data value associated at the message, is possible to cast at void* pointer and use it to pass more data; remember origin data must be static
    \param pThreadIDorg is the thread that send the message, if you don't have this information, then set it to CDTHREADID_NOTHREAD
-   \return CDMESSAGEID_ERROR if doesn't find any available position or happen an error, or positive number that indicates new cdmessageID
+   \return CDMESSAGEID_ERROR if doesn't find any available position or happen an error, or positive number that indicates new cdmessageID  
    \see cdmessage_getData
    \version 1.01
 */
@@ -144,14 +147,14 @@ cdMessageID_t cdmessage_new(cdThreadID_t pThreadIDdest, cdMsgInfo_t pInfoVal, cd
    thRealIdx = cdthread_getArrayIdxFromID(pThreadIDdest);
    if (thRealIdx < 0) return CDMESSAGEID_ERROR;
    //check if thread is destroyed, so is impossible to sent a message and return an error
-   if (cdthreadsSystemArray[thRealIdx].ID==CDTHREADID_ERROR) return CDMESSAGEID_ERROR;
+   if (cdthreadsSystemArray[(uint16_t)thRealIdx].ID == CDTHREADID_ERROR ) return CDMESSAGEID_ERROR;
       
    //get the new message struct   
    idx= cdmessage_getFreeID();
    //check if not finds a available message struct
-   if (idx==CDMESSAGEID_ERROR) return CDMESSAGEID_ERROR;
+   if (idx == CDMESSAGEID_ERROR) return CDMESSAGEID_ERROR;
    //get a pointer to nmessage struct
-   MsgPtr =  &cdmessagesSystemArray[(int)idx - 1];
+   MsgPtr =  &cdmessagesSystemArray[(uint16_t)(idx - 1)];
    // initialize values   
    MsgPtr->cdthID=pThreadIDdest;
    MsgPtr->State=CDMESSAGESTATE_NEWMSG;
@@ -163,23 +166,23 @@ cdMessageID_t cdmessage_new(cdThreadID_t pThreadIDdest, cdMsgInfo_t pInfoVal, cd
 
    //now add to the thread message queue this message
    //check if there isn't other messages on the queue, in this case....
-   if(cdthreadsSystemArray[thRealIdx].MessagesCounter <= 0){
+   if(cdthreadsSystemArray[(uint16_t)thRealIdx].MessagesCounter <= 0){
       //if there isn't others messages on the queue then...
-      cdthreadsSystemArray[thRealIdx].FirstMsgID = idx;
-      cdthreadsSystemArray[thRealIdx].LastMsgID = idx;
-      cdthreadsSystemArray[thRealIdx].MessagesCounter=1;
+      cdthreadsSystemArray[(uint16_t)thRealIdx].FirstMsgID = idx;
+      cdthreadsSystemArray[(uint16_t)thRealIdx].LastMsgID = idx;
+      cdthreadsSystemArray[(uint16_t)thRealIdx].MessagesCounter=1;
    }else{ //if(cdthreadsSystemArray[thRealIdx].MessagesCounter <= 0)
       //if there is others messages on the queue then...
-      othIdx = cdthreadsSystemArray[thRealIdx].LastMsgID;
-      cdthreadsSystemArray[thRealIdx].LastMsgID = idx;
+      othIdx = cdthreadsSystemArray[(uint16_t)thRealIdx].LastMsgID;
+      cdthreadsSystemArray[(uint16_t)thRealIdx].LastMsgID = idx;
       //now change the NextMsgID of previouse "lastMsgID" to this message id
       //remember that
       appoInt = cdmessage_getArrayIdxFromID(othIdx); 
       //if conversion happen without errors then...
-      if(appoInt>=0){
-          cdmessagesSystemArray[appoInt].NextMsgID = idx;
+      if(appoInt >= 0){
+          cdmessagesSystemArray[(uint16_t)appoInt].NextMsgID = idx;
       }
-      cdthreadsSystemArray[thRealIdx].MessagesCounter++;         
+      cdthreadsSystemArray[(uint16_t)thRealIdx].MessagesCounter++;         
    } //end else if(cdthreadsSystemArray[thRealIdx].MessagesCounter <= 0)
    return idx;   //return the new cdMessageID added to thread
 }
@@ -191,7 +194,7 @@ cdMessageID_t cdmessage_new(cdThreadID_t pThreadIDdest, cdMsgInfo_t pInfoVal, cd
    \date 13-11-2015
    \brief creates new message with a pointer to data, and adds it to message queue of indicated thread
     As the same function of cdmessage_new(..) but convert (casting) ptrData memory pointer in a cdMsgData_t type and store it as a simple data.
-   \n If no data and thread to add at this message please use cdmessage_new( pThreadID , pInfoVal, 0 , CDMESSAGEDATA_NODATA, CDTHREADID_NOTHREAD )
+   \n If no data and thread to add at this message please use cdmessage_new( pThreadID , pInfoVal, 0 , CDMESSAGEDATA_NODATAPTR, CDTHREADID_NOTHREAD )
    \param pThreadIDdest is the thread where message will be asent (added to msg thread queue)
    \param pInfoVal is an integer that inform receiver what is the message (is a number and values must be user defined)
    \param ptrData is the pointer to the data
@@ -201,7 +204,7 @@ cdMessageID_t cdmessage_new(cdThreadID_t pThreadIDdest, cdMsgInfo_t pInfoVal, cd
    \see cdmessage_getDataPointer
    \version 1.01
 */
-#inline
+//#inline
 cdMessageID_t cdmessage_new_DataPtr(cdThreadID_t pThreadIDdest, cdMsgInfo_t pInfoVal, void* ptrData, cdThreadID_t pThreadIDorg )
 {
     return cdmessage_new(pThreadIDdest, pInfoVal, (cdMsgData_t) ptrData, pThreadIDorg );
@@ -211,26 +214,26 @@ cdMessageID_t cdmessage_new_DataPtr(cdThreadID_t pThreadIDdest, cdMsgInfo_t pInf
 
 
 
-/*! \fn int cdmessage_deleteAllMsgWithThreadID( cdThreadID_t pThId )
+/*! \fn sint_t cdmessage_deleteAllMsgWithThreadID( cdThreadID_t pThId )
    \author Dario Cortese
    \date 09-08-2012 modified 2015-11-05
    \brief delete  all messages in the message system array that have cdthID equal pThId (as is delete all messages associated at indicated thread)
    \return true if all ok otherwise return false if an error happen
    \version 1.00
 */
-int cdmessage_deleteAllMsgWithThreadID( cdThreadID_t pThId ){
+sint_t cdmessage_deleteAllMsgWithThreadID( cdThreadID_t pThId ){
    cdMessageID_t idx;
    if(!cdthread_checkValidID( pThId)) return FALSE;
    for(idx=0; idx < CDTHREAD_MAX_NUM_MESSAGES; idx++){
-      if(cdmessagesSystemArray[idx].cdthID== pThId){
-         cdmessagesSystemArray[idx].State=CDMESSAGESTATE_DELETED;//free/available position
+      if(cdmessagesSystemArray[(uint16_t)idx].cdthID== pThId){
+         cdmessagesSystemArray[(uint16_t)idx].State=CDMESSAGESTATE_DELETED;//free/available position
       }
    }
    return TRUE;
 }
 
 
-/*! \fn int cdmessage_deleteMsg( cdMessageID_t pMsgId )
+/*! \fn sint_t cdmessage_deleteMsg( cdMessageID_t pMsgId )
    \author Dario Cortese
    \date 09-08-2012 modified 2015-11-05
    \brief deletes this message from messages system array and remove it from message queue of connected thread (only if is the first msg of queue)
@@ -238,44 +241,44 @@ int cdmessage_deleteAllMsgWithThreadID( cdThreadID_t pThId ){
    \return true if all ok otherwise return false if an error happen
    \version 1.00
 */
-int cdmessage_deleteMsg( cdMessageID_t pMsgId ){
+sint_t cdmessage_deleteMsg( cdMessageID_t pMsgId ){
    cdMessageID_t idx;
    cdThreadID_t thID;
    cdThreadID_t thIdx;
    idx = cdmessage_getArrayIdxFromID(pMsgId);
    if(idx < 0) return FALSE;   //indicate an error
-   cdmessagesSystemArray[idx].State=CDMESSAGESTATE_DELETED;//free/available position
+   cdmessagesSystemArray[(uint16_t)idx].State=CDMESSAGESTATE_DELETED;//free/available position
    //remove this message from message thread queue
    //take thread id of this message
-   thID = cdmessagesSystemArray[idx].cdthID;
+   thID = cdmessagesSystemArray[(uint16_t)idx].cdthID;
    //check if this thread is valid
    thIdx = cdthread_getArrayIdxFromID(thID);
    if( thIdx >= 0){
       //proceed to remove message from msg thread queue
       //check if this thread is deleted, in this case delete every message is used for it
-      if( cdthreadsSystemArray[thIdx].ID==CDTHREADID_ERROR ){
+      if( cdthreadsSystemArray[(uint16_t)thIdx].ID == CDTHREADID_ERROR ){
          cdmessage_deleteAllMsgWithThreadID( thID );
       }else{
          //if thread isn' delted then check if there is message on queue
-         if(cdthreadsSystemArray[thIdx].MessagesCounter<=0){
+         if(cdthreadsSystemArray[(uint16_t)thIdx].MessagesCounter <= 0){
             //this is a abnormal case because this message isnt in queue so is an error, 
             // in this case sign FirstMsgID and LastMsgID as CDMESSAGEID_ERROR and search to delete every message with this threadID
-            cdthreadsSystemArray[thIdx].FirstMsgID=CDMESSAGEID_ERROR;
-            cdthreadsSystemArray[thIdx].LastMsgID=CDMESSAGEID_ERROR;
+            cdthreadsSystemArray[(uint16_t)thIdx].FirstMsgID = CDMESSAGEID_ERROR;
+            cdthreadsSystemArray[(uint16_t)thIdx].LastMsgID = CDMESSAGEID_ERROR;
             cdmessage_deleteAllMsgWithThreadID( thID );
          }else{ //if(cdthreadsSystemArray[thIdx].MessagesCounter<=0)
             //if there is a message then check if this is the first, in this case procede to remove it from queue;
             //if this message isn't the first of thread msg queue than do nothing because is unmanageable error
-            if( cdthreadsSystemArray[thIdx].FirstMsgID== pMsgId){
+            if( cdthreadsSystemArray[(uint16_t)thIdx].FirstMsgID == pMsgId){
                //assign this NextMsgID to thread msg queue start point 
-               cdthreadsSystemArray[thIdx].FirstMsgID=cdmessagesSystemArray[idx].NextMsgID;
+               cdthreadsSystemArray[(uint16_t)thIdx].FirstMsgID = cdmessagesSystemArray[(uint16_t)idx].NextMsgID;
                //decrement msg counter
-               cdthreadsSystemArray[thIdx].MessagesCounter--;
+               cdthreadsSystemArray[(uint16_t)thIdx].MessagesCounter--;
             } 
             //if no other messages threre is in the queue then .....
-            if(cdthreadsSystemArray[thIdx].MessagesCounter<=0){
-               cdthreadsSystemArray[thIdx].FirstMsgID=CDMESSAGEID_ERROR;
-               cdthreadsSystemArray[thIdx].LastMsgID=CDMESSAGEID_ERROR;
+            if(cdthreadsSystemArray[(uint16_t)thIdx].MessagesCounter<=0){
+               cdthreadsSystemArray[(uint16_t)thIdx].FirstMsgID=CDMESSAGEID_ERROR;
+               cdthreadsSystemArray[(uint16_t)thIdx].LastMsgID=CDMESSAGEID_ERROR;
                //only for safe check if there is other messages with this thread id and delte they
                cdmessage_deleteAllMsgWithThreadID( thID );
             }
@@ -287,7 +290,7 @@ int cdmessage_deleteMsg( cdMessageID_t pMsgId ){
 
 
 
-/*! \fn int cdmessage_sigMsgAsReaded( cdMessageID_t pMsgId )
+/*! \fn sint_t cdmessage_sigMsgAsReaded( cdMessageID_t pMsgId )
    \author Dario Cortese
    \date 09-08-2012 modified 2015-11-05
    \brief sign this message as readed, if action has success then return true 
@@ -295,17 +298,17 @@ int cdmessage_deleteMsg( cdMessageID_t pMsgId ){
    \return true if all ok otherwise return flase if an error happen
    \version 1.00
 */
-int cdmessage_sigMsgAsReaded( cdMessageID_t pMsgId ){
+sint_t cdmessage_sigMsgAsReaded( cdMessageID_t pMsgId ){
    cdMessageID_t idx;
    idx = cdmessage_getArrayIdxFromID(pMsgId);
    if(idx < 0) return FALSE;   //indicate an error
-   cdmessagesSystemArray[idx].State=CDMESSAGESTATE_READED;//free/available position
+   cdmessagesSystemArray[(uint16_t)idx].State = CDMESSAGESTATE_READED;//free/available position
    return TRUE;
 }
 
 
 
-/*! \fn int cdmessage_isReaded( cdMessageID_t pMsgId )
+/*! \fn sint_t cdmessage_isReaded( cdMessageID_t pMsgId )
    \author Dario Cortese
    \date 09-08-2012 modified 2015-11-05
    \brief checks if this message was readed and returns true, this means that could be only readed or yet deleted; returns false also an error happen
@@ -313,18 +316,18 @@ int cdmessage_sigMsgAsReaded( cdMessageID_t pMsgId ){
    \return true if message was readed or deleted (readed and after deleted), otherwise false, also an error happen (ie: id ID is invalid)
    \version 1.00
 */
-int cdmessage_isReaded( cdMessageID_t pMsgId ){
+sint_t cdmessage_isReaded( cdMessageID_t pMsgId ){
    cdMessageID_t idx;
    idx = cdmessage_getArrayIdxFromID(pMsgId);
    if(idx < 0) return FALSE;   //indicate an error
-   if(cdmessagesSystemArray[idx].State==CDMESSAGESTATE_READED) return TRUE;
-   if(cdmessagesSystemArray[idx].State==CDMESSAGESTATE_DELETED) return TRUE;
+   if(cdmessagesSystemArray[(uint16_t)idx].State == CDMESSAGESTATE_READED) return TRUE;
+   if(cdmessagesSystemArray[(uint16_t)idx].State == CDMESSAGESTATE_DELETED) return TRUE;
    return FALSE;
 }
 
 
 
-/*! \fn int cdmessage_isDeleted( cdMessageID_t pMsgId )
+/*! \fn sint_t cdmessage_isDeleted( cdMessageID_t pMsgId )
    \author Dario Cortese
    \date 09-08-2012 modified 2015-11-05
    \brief checks if this message was deleted and returns true otherwise returns false (also an error happen)
@@ -332,11 +335,11 @@ int cdmessage_isReaded( cdMessageID_t pMsgId ){
    \return true if message was deleted (readed and after deleted), otherwise false, also if an error happen (ie: id ID is invalid)
    \version 1.00
 */
-int cdmessage_isDeleted( cdMessageID_t pMsgId ){
+sint_t cdmessage_isDeleted( cdMessageID_t pMsgId ){
    cdMessageID_t idx;
    idx = cdmessage_getArrayIdxFromID(pMsgId);
    if(idx < 0) return FALSE;   //indicate an error
-   if(cdmessagesSystemArray[idx].State==CDMESSAGESTATE_DELETED) return TRUE;
+   if(cdmessagesSystemArray[(uint16_t)idx].State==CDMESSAGESTATE_DELETED) return TRUE;
    return FALSE;
 }
 
@@ -353,7 +356,7 @@ cdThreadID_t cdmessage_getSenderThread( cdMessageID_t pMsgId ){
    cdMessageID_t idx;
    idx = cdmessage_getArrayIdxFromID(pMsgId);
    if(idx < 0) return CDTHREADID_ERROR;   //indicate an error
-   return cdmessagesSystemArray[idx].cdthSenderID;
+   return cdmessagesSystemArray[(uint16_t)idx].cdthSenderID;
 }
 
 
@@ -372,7 +375,7 @@ cdMsgData_t cdmessage_getData( cdMessageID_t pMsgId ){
    idx = cdmessage_getArrayIdxFromID(pMsgId);
    if(idx < 0) return 0;   //indicate an error
    //if(cdmessagesSystemArray[idx].Data <= 0) return 0;
-   return cdmessagesSystemArray[idx].Data;
+   return cdmessagesSystemArray[(uint16_t)idx].Data;
 }
 
 
@@ -381,16 +384,16 @@ cdMsgData_t cdmessage_getData( cdMessageID_t pMsgId ){
    \date 09-08-2012 modified 2015-11-13
    \brief return memory pointer, is the data attached to the message converted in a memory pointer; is the same think that (void *)cdmessage_getData( pMsgId )
    \param pMsgId is the cdMessageID to check
-   \return the data converted in a vois* , if error happen return a pointer to address 0
- * \see cdmessage_getData
+   \return the data converted in a void* , if error happen return a pointer to address 0
+   \see cdmessage_getData
    \version 1.00
 */
 void* cdmessage_getDataPointer( cdMessageID_t pMsgId ){
    cdMessageID_t idx;
    idx = cdmessage_getArrayIdxFromID(pMsgId);
-   if(idx < 0) return CDMESSAGEDATA_NODATA;   //indicate an error
-   return (void *)cdmessagesSystemArray[idx].Data;
-   
+   if(idx < 0) return CDMESSAGEDATA_NODATAPTR;   //indicate an error
+   return (void *)cdmessagesSystemArray[(uint16_t)idx].Data;
+ 
 }
 
 
@@ -400,14 +403,14 @@ void* cdmessage_getDataPointer( cdMessageID_t pMsgId ){
    \date 10-08-2012 modified 2015-11-05
    \brief return the info value for indicated message
    \param pMsgId is the cdMessageID to check
-   \return the info value stored int indicated message; if an error happen return 0 (but 0 is a default value, not a error value)
+   \return the info value stored sint_t indicated message; if an error happen return 0 (but 0 is a default value, not a error value)
    \version 1.00
 */
 cdMsgInfo_t cdmessage_getInfo( cdMessageID_t pMsgId ){
    cdMessageID_t idx;
    idx = cdmessage_getArrayIdxFromID(pMsgId);
    if(idx < 0) return 0;   //indicate an error
-   return cdmessagesSystemArray[idx].Info;
+   return cdmessagesSystemArray[(uint16_t)idx].Info;
 }
 
 

--- a/CDRoundstream.h
+++ b/CDRoundstream.h
@@ -6,9 +6,10 @@
 //// without written permission.                                        ////
 ////                                                                    ////
 //// Author: Dario Cortese                                              ////
-//// Client: myself                                                     ////
+//// Client: Mongoose srl (Mariano Cerbone)                             ////
 //// User: Dario Cortese                                                ////
 //// Created on 08/05/2013  modified 04-11-2015                         ////
+//// Modify on 10/02/2019 to be adapted at CCS compiler                 ////
 //// File: cdRoundstream.h                                              ////
 //// Description:                                                       ////
 ////    This file has the variable, structure and function definition   ////
@@ -210,13 +211,21 @@ typedef struct CDRStream_struct_tag{
 	//int autoFlush;		//!< boolean that indicates if reset counter when there isn't vals to be read (all vals read)
  }CDRStream_t;
 
-#define CDRSTREAMERR_NO_ERROR	 0x0000
-#define CDRSTREAMERR_UNITIALIZED 0x0001
-#define CDRSTREAMERR_READ_EMPTY	 0x0002
-#define CDRSTREAMERR_OVERWRITE	 0x0004
+ 
+//CDRStream_t.errors defines 
+#define CDRSTREAMERR_UNITIALIZED  0x0000
+#define CDRSTREAMERR_NO_ERROR	  0x0001
+#define CDRSTREAMERR_READ_EMPTY	  0x0002
+#define CDRSTREAMERR_OVERWRITE	  0x0004
+#define CDRSTREAMERR_BADPTRBUFF	  0x0008
+#define CDRSTREAMERR_BADBUFFSIZE  0x0010
 
- 
- 
+//for read error, active only CDRSTREAMERR_BADPTRBUFF, CDRSTREAMERR_BADBUFFSIZE, CDRSTREAMERR_OVERWRITE 
+//remember that result of this mask must be equal to CDRSTREAMERR_UNITIALIZED
+#define CDRSTREAMERR_ERRMASKWRITE 0x001D
+//for read error, active only CDRSTREAMERR_BADPTRBUFF, CDRSTREAMERR_BADBUFFSIZE, CDRSTREAMERR_READ_EMPTY
+//remember that result of this mask must be equal to CDRSTREAMERR_UNITIALIZED
+#define CDRSTREAMERR_ERRMASKREAD  0x001B 
 
 sint_t cdRStreamInit(CDRStream_t* pStream, CDRStream_data_t* pPtrBuff, CDRStream_counters_t pBuffSize);	//!< initialize the streamer data (and structure)
  
@@ -248,51 +257,51 @@ sint_t UINT8tocdRStream(CDRStream_t* cds, uint8_t pByte);       //!< add one val
 
 
 
-/*-! \def cdRStreamLastReadVal(xx)
+/*-! \def cdRStreamLastReadVal(xYx)
 	reads last read value from the function getval and pregetval
-	\n Param xx is pStream pointer to CDstream (data structure)
+	\n Param xYx is pStream pointer to CDstream (data structure)
 */
-//#define cdRStreamLastReadVal(xx) (((CDRStream_struct*)(xx))->lastReadValue)
+//#define cdRStreamLastReadVal(xYx) (((CDRStream_struct*)(xYx))->lastReadValue)
 
 
-/*! \def cdRStreamAllReadings(xx)
+/*! \def cdRStreamAllReadings(xYx)
 	reads the number of values read from stream initialization
-	\n Param xx is pStream pointer to CDstream (data structure)
+	\n Param xYx is pStream pointer to CDstream (data structure)
 */
-#define cdRStreamAllReadings(xx) (((CDRStream_struct*)(xx))->Readings)
+#define cdRStreamAllReadings(xYx) (((CDRStream_struct*)(xYx))->Readings)
 
-/*! \def cdRStreamAllWritings(xx)
+/*! \def cdRStreamAllWritings(xYx)
 	reads the number of values read from stream initialization
-	\n Param xx is pStream pointer to CDstream (data structure)
+	\n Param xYx is pStream pointer to CDstream (data structure)
 */
-#define cdRStreamAllWritings(xx) (((CDRStream_struct*)(xx))->Writings)
+#define cdRStreamAllWritings(xYx) (((CDRStream_struct*)(xYx))->Writings)
 
 
-/*! \def cdRStreamGetSize(xx)
+/*! \def cdRStreamGetSize(xYx)
 	return the size of stream buffer in number of storable Vals (int16)
-	\n Param xx is pStream pointer to CDstream (data structure)
+	\n Param xYx is pStream pointer to CDstream (data structure)
 */
-#define cdRStreamGetSize(xx) (((CDRStream_struct*)(xx))->buffSize)
+#define cdRStreamGetSize(xYx) (((CDRStream_struct*)(xYx))->buffSize)
 
 
 //void cdstreamBlockRead(CDRStream_struct* pStream, int pBlock);	//!< block or re-enable the read for stream
-/*!	\def cdRStreamBlockRead(xx,yy)
+/*!	\def cdRStreamBlockRead(xYx,yXy)
 	If set block = true then when ask number of readable vals it always return 0 regardless of the reality, and
 	 if you attempt to read a value from stream it will generate an error.
-	\n When block is removed (yy =false) then the available byte in stream to be read is the reality.
-	\n When block is active (yy=true), is possible to write data in the stream without any error, but is impossible to read
+	\n When block is removed (yXy =false) then the available byte in stream to be read is the reality.
+	\n When block is active (yXy=true), is possible to write data in the stream without any error, but is impossible to read
 	   values or ask number of readable vals in stream.
-	\n Param xx is pStream pointer to CDstream (data structure)
-	\n Param yy is a boolean (int) with value true or false
+	\n Param xYx is pStream pointer to CDstream (data structure)
+	\n Param yXy is a boolean (int) with value true or false
 */
-#define cdRStreamBlockRead(xx,yy) ((CDRStream_struct*)(xx))->blockRead=(yy)
+#define cdRStreamBlockRead(xYx,yXy) ((CDRStream_struct*)(xYx))->blockRead=(yXy)
 
 
-/*! \def cdRStreamIsBlockedRead(xx)
+/*! \def cdRStreamIsBlockedRead(xYx)
 	indicates if stream reading is blocked (return true) or enabled (return false)
-	\n Param xx is pStream pointer to CDstream (data structure)
+	\n Param xYx is pStream pointer to CDstream (data structure)
 */
-#define cdRStreamIsBlockedRead(xx) (((CDRStream_struct*)(xx))->blockRead)
+#define cdRStreamIsBlockedRead(xYx) (((CDRStream_struct*)(xYx))->blockRead)
 
 
 

--- a/CDThread.h
+++ b/CDThread.h
@@ -6,8 +6,9 @@
 //// without written permission.                                        ////
 ////                                                                    ////
 //// Author: Dario Cortese                                              ////
-//// Client: I.S.A. srl                                                 ////
-//// Created on 02/08/2012 modified 2015-11-04                          ////
+//// Client: Mongoose srl (Mariano Cerbone)                             ////
+//// Created on 02/08/2012                                              ////
+//// Modify on 10/02/2019 to be adapted at CCS compiler                 ////
 //// File: cdthread.h                                                   ////
 //// Description:                                                       ////
 ////    This file has the variable, structure and function definition   ////
@@ -61,7 +62,7 @@
 ////   THREAD, AND IN THIS CASE THE THREAD ENGINE SKIPS THEIR ANALYSYS  ////
 ////   AND EXECUTION.                                                   ////
 //// To create and register a new thread for engine use...              ////
-////   cdThreadID_t ThreadID= CDTHREADID_NOTHREAD;                        ////
+////   cdThreadID_t ThreadID= CDTHREADID_NOTHREAD;                      ////
 ////   int allOk; //to know if callfunction was called                  ////
 ////   allOk = cdthread_new(&ThreadID, functionForThread);              ////
 //// To create and register a new thread for user (not used in engine)  ////
@@ -77,7 +78,7 @@
 ////   allOk = cdthread_changeFunction(ThreadID, FunctionForThread);    ////
 //// To call by user code a user managed thread (or a engined thread)   ////
 ////   use...                                                           ////
-////   int fctExitCode;   //used to know exit code of callback function   ////
+////   int fctExitCode;   //used to know exit code of callback function ////
 ////   int allOk; //to know if callfunction was called                  ////
 ////   allOk = cdthread_UserCallThreadFunction(ThreadID, &fctExitCode); ////
 ////                                                                    ////
@@ -89,7 +90,7 @@
 ////   cdthread_DestroyThread( &ThreadID);                              ////
 ////                                                                    ////
 //// To check if ThreadID refers to a destroyed thread use..            ////
-////   int isKo; //to know if destroyed, true=destroyed, false=exist      ////
+////   int isKo; //to know if destroyed, true=destroyed, false=exist    ////
 ////   isKo = cdthread_isDestroyed(ThreadID);                           ////
 ////                                                                    ////
 //// To check if ThreadID exist (valid and thread not destroyed)        ////
@@ -103,7 +104,7 @@
 ////   int Priority = CDTHREADPRIORITY_ENABLED; //lower enabled priority////
 ////   allOk = cdthread_Enable(ThreadID, Priority);                     ////
 //// To disable thread use ...                                          ////
-////   allOk = cdthread_Disable(cdThreadID_t pThId);                      ////
+////   allOk = cdthread_Disable(cdThreadID_t pThId);                    ////
 ////                                                                    ////
 //// To know if thread is enabled use the function....                  ////
 ////  cdthread_isEnabled(ThreadID) that return a true if enabled        ////
@@ -142,9 +143,9 @@
 ////                                                                    ////
 //// TO CREATE A NEW MESSAGE FOR A SPECIFIC THREAD USE...               ////
 ////   cdMessageID msgID;                                               ////
-////   int info= 1;   //this is the code for message used inside      ////
+////   int info= 1;   //this is the code for message used inside        ////
 ////                    //the thread to determine which message is      ////
-////   int NumData=10;   //this is the number (logical, not the size in  ////
+////   int NumData=10;   //this is the number (logical, not the size in ////
 ////                    //byte) of data                                 ////
 //// IS VERY IMPORTANT THAT DATA DON'T STAY IN STACK OR VOLATILE ZONE   ////
 //// BECAUSE DATA AREN'T COPIED IN THE MESSAGE, BUT ONLY A POINTER IS   ////
@@ -163,8 +164,8 @@
 ////                                         is one or more messages    ////
 //// TO READ THE MESSAGE ID, AND SO READS ITS DATA, INSIDE THE THREAD   ////
 ////   FUNCTION use...                                                  ////
-////   cdMessageID msgID;                                             ////
-////   msgID = cdthread_getMessage(ThisThread);                       ////
+////   cdMessageID msgID;                                               ////
+////   msgID = cdthread_getMessage(ThisThread);                         ////
 //// IT SIGN ALSO THE MESSAGE AS READED, SO EXTERNALLY COULD BE DETECTED////
 //// To detect externally to thread function the happened read message..////
 ////   cdmessage_isReaded(msgID); //msgID returned when created the msg,////
@@ -222,7 +223,7 @@
 ////                                                                    ////
 //// int ThreadFunctionSample(int firstTime, cdThreadID_t ThisThread, ..////
 ////                          int prevExitCode){                        ////
-//// ....}                                                              ////
+//// ....}                                                             ////
 ////                                                                    ////
 //// THE THREAD FUNCTION MUST RETURN A VALUE THAT IS EXIT STATUS; THIS  ////
 ////   PREVIOUS STATUS MUST BE READED BY THREAD FUNCTION, SO IT CAN     ////
@@ -258,7 +259,7 @@
 //// cdTimerID myTimer1, myTimer2, myTimer3, myTimer4;                  ////
 //// myTimer1 = cdtimer_setupTicks(20);  //timer value for wait 20ticks ////
 //// myTimer2 = cdtimer_setup_s(1);     //timer value for wait 1second  ////
-//// myTimer3 = cdtimer_setupms(10);     //timer value for wait 10ms    ////
+//// myTimer3 = cdtimer_setup_ms(10);     //timer value for wait 10ms    ////
 //// myTimer4 = cdtimer_setupus(50);     //timer value for wait 50us    ////
 //// while( cdtimer_isNotExpired(myTimer1) ){                           ////
 ////   ....                                                             ////
@@ -274,7 +275,7 @@
 ////   static cdTimerID myTimer1=0;                                     ////
 ////   if( myTimer1!=0 ) goto LABEL_timer_here;                         //// 
 ////   //place here code to execute before start timer                  ////
-////   myTimer1 = cdtimer_setupms(1); //timer value for wait 1ms        ////
+////   myTimer1 = cdtimer_setup_ms(1); //timer value for wait 1ms        ////
 //// LABEL_timer_here:                                                  //// 
 ////   if( cdtimer_isNotExpired(myTimer1) ) return 0;                   ////
 ////   //place here code to execute when timer expired                  ////
@@ -364,30 +365,34 @@ LABEL_STATE3:
 ////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////
 
-#ifndef _CDTHREAD_H_
-#define _CDTHREAD_H_
+#ifndef __CDTHREAD_H__
+#define __CDTHREAD_H__
 
 #include "CD_types.h"
 
 /*! \def CDTHREAD_MAX_NUM_THREADS
    used to indicates the absolute maximun number of thread that the system could have (thread array size)
+   \n Remember that one is reserved for thread_alwais (logical ID 1 or thread array index 0)  
 */
-#define  CDTHREAD_MAX_NUM_THREADS   5
+#define  CDTHREAD_MAX_NUM_THREADS   16
 
 /*! \def CDTHREAD_MAX_NUM_MESSAGES
    used to indicates the absolute maximun number of messages that the system could have (thread array size)
 */
-#define  CDTHREAD_MAX_NUM_MESSAGES   8
+#define  CDTHREAD_MAX_NUM_MESSAGES   24
 
 //cdMessageID_t, always signed, but on 8bit platform means 127 messages maximun, on 16bit platform means 32767 messages maximun and so on
-typedef sint_t cdMessageID_t;   //!< cdmessage id type, used to store id message that is used by every function
+//sint16_t needed for a problem of ccs in array offset calculation, probably for optimization code use index of array for offset calculation, 
+// so if offset is > than 128 an error happen; this is enormous error but today solve it changing the ID
+typedef sint16_t cdMessageID_t;   //!< cdmessage id type, used to store id message that is used by every function
 typedef sint_t cdMsgInfo_t;     //!< message info type, used to store info value associated to the message
 typedef sint16_t cdMsgData_t;   //!< message data, used to store the a data (because this could be a memory pointer (casting to void*) this must be almost the size of a pointer [16bit for less than 65535 address space or a 32bit])
 
 //on 8 bit platform means 127 threads
 //on 16bit platororm means 32767 threads
-typedef sint_t cdThreadID_t ;   //!< cdthread id type, used to store id message that is used by every function
-
+//sint16_t needed for a problem of ccs in array offset calculation, probably for optimization code use index of array for offset calculation, 
+// so if offset is > than 128 an error happen; this is enormous error but today solve it changing the ID
+typedef sint16_t cdThreadID_t ;   //!< cdthread id type, used to store id message that is used by every function
 
 //*********************************************************************
 //*************messages************************************************
@@ -396,7 +401,7 @@ typedef sint_t cdThreadID_t ;   //!< cdthread id type, used to store id message 
 
 
 
-typedef struct cdMessageStruct_tag{
+typedef struct {
    cdThreadID_t cdthID ;    //!< a number that identify unequivocal to which thread is associated this message
    int State;           //!< 2=new message, 1=readed but do not delete, 0=was managed and so is deletable 
    //void* ptrData;        //!< pointer to memory where is stored data for this message
@@ -406,6 +411,13 @@ typedef struct cdMessageStruct_tag{
    cdThreadID_t cdthSenderID ;    //!< a number that identify unequivocal to which thread is sender of this message
 }cdmessageStruct;
 
+typedef struct {
+   cdMessageID_t actMsg;        //!< actual message ID, remember to set at CDMESSAGEID_ERROR after message destroy
+   cdMsgData_t  msgData;        //!< the data of the message (because could be a memory pointer (casting to void*) this must be almost the size of a memory pointer [16bit for less than 65535 address space or a 32bit])
+   cdMsgInfo_t  msgInfo;        //!< a information value, is optional and is a user value used to inform receiver
+   cdThreadID_t msgSender ;     //!< a number that identify unequivocal to which thread is sender of this message
+}cdmessageData_t;
+
 
 
 /*!   \var cdmessageStruct cdmessagesSystemArray
@@ -414,13 +426,16 @@ typedef struct cdMessageStruct_tag{
 extern cdmessageStruct cdmessagesSystemArray[CDTHREAD_MAX_NUM_MESSAGES];
 
 
-
-
-
 /*! \def CDMESSAGEDATA_NODATA
    used in cdmessageStruct.ptrData to assign a no available pointer to data
 */
-#define CDMESSAGEDATA_NODATA      (void*)0x00000000
+#define CDMESSAGEDATA_NODATA         0x00000000
+
+/*! \def CDMESSAGEDATA_NODATAPTR
+   used in cdmessageStruct.ptrData to assign a no available pointer to data
+*/
+#define CDMESSAGEDATA_NODATAPTR      (void*)0x00000000
+
 
 
 
@@ -452,14 +467,14 @@ extern cdmessageStruct cdmessagesSystemArray[CDTHREAD_MAX_NUM_MESSAGES];
 /*! \def cdmessage_isErrorID(x)
    macro used to check if cdMessageID 'x' is an error id (==CDMESSAGEID_ERROR)
 */
-#define cdmessage_isErrorID(x)      ( x == CDMESSAGEID_ERROR)
+#define cdmessage_isErrorID( YxY )      ( YxY == CDMESSAGEID_ERROR)
 
 
 /*! \def cdmessage_checkValidID(x)
    checks if cdMessageID 'x' is a valid ID, this means that isn't a CDMESSAGEID_ERROR and is inside from 0 to CDTHREAD_MAX_NUM_MESSAGES.
    \n return true if is valid otherwisw return false
 */
-#define cdmessage_checkValidID( YY )   (( YY !=CDMESSAGEID_ERROR)&&( YY >=0)&&( YY <=CDTHREAD_MAX_NUM_MESSAGES))
+#define cdmessage_checkValidID( YxY )   (( YxY !=CDMESSAGEID_ERROR)&&( YxY >=0)&&( YxY <=CDTHREAD_MAX_NUM_MESSAGES))
 
 
 
@@ -471,28 +486,30 @@ cdMessageID_t cdmessage_getFreeID(); //!< searh free/available position in syste
 cdMessageID_t cdmessage_getArrayIdxFromID(cdMessageID_t pMsgId); //!< returns the real index for cdmessagesSystemArray extracted from indicated cdMessageID (pMsgId)
 
 cdMessageID_t cdmessage_new(cdThreadID_t pThreadIDdest, cdMsgInfo_t pInfoVal, cdMsgData_t pData, cdThreadID_t pThreadIDorg ); //!< creates new message, and adds it to message queue of indicated thread
-#inline cdMessageID_t cdmessage_new_DataPtr(cdThreadID_t pThreadIDdest, cdMsgInfo_t pInfoVal, void* ptrData, cdThreadID_t pThreadIDorg ); //!< creates new message with a pointer to data, and adds it to message queue of indicated thread
-int cdmessage_deleteMsg( cdMessageID_t pMsgId );           //!< delete  this message from messages system array and remove it from message queue of connected thread (only if is the first msg of queue)
+//#inline cdMessageID_t cdmessage_new_DataPtr(cdThreadID_t pThreadIDdest, cdMsgInfo_t pInfoVal, void* ptrData, cdThreadID_t pThreadIDorg ); //!< creates new message with a pointer to data, and adds it to message queue of indicated thread
+//remenber: data pointed by ptrData must be static or global otherwise the reader will read wrong and unpredictable data
+cdMessageID_t cdmessage_new_DataPtr(cdThreadID_t pThreadIDdest, cdMsgInfo_t pInfoVal, void* ptrData, cdThreadID_t pThreadIDorg ); //!< creates new message with a pointer to data, and adds it to message queue of indicated thread
+sint_t cdmessage_deleteMsg( cdMessageID_t pMsgId );           //!< delete  this message from messages system array and remove it from message queue of connected thread (only if is the first msg of queue)
 
 
-int cdmessage_deleteAllMsgWithThreadID( cdThreadID_t pThId ); //!< delete  all messages in the message system array that have cdthID equal pThId
+sint_t cdmessage_deleteAllMsgWithThreadID( cdThreadID_t pThId ); //!< delete  all messages in the message system array that have cdthID equal pThId
 
-int cdmessage_sigMsgAsReaded( cdMessageID_t pMsgId );   //!< sign this message as readed, if action has success then return true
+sint_t cdmessage_sigMsgAsReaded( cdMessageID_t pMsgId );   //!< sign this message as readed, if action has success then return true
 
-int cdmessage_isReaded( cdMessageID_t pMsgId );         //!< checks if this message was readed and returns true, this means that could be only readed or yet deleted; returns false also an error happen
-int cdmessage_isDeleted( cdMessageID_t pMsgId );        //!< check if this message was deleted and return true otherwise return false (also an error happen)
-cdMsgData_t cdmessage_getData( cdMessageID_t pMsgId );       //!< return the number of logical data attached to message; if there isn't, or an error happens, return 0
-void* cdmessage_getDataPointer( cdMessageID_t pMsgId ); //!< return pointer to memory where is the data attached to indicated message; if there isn't, or an error happens, return CDMESSAGEDATA_NODATA
-cdMsgInfo_t cdmessage_getInfo( cdMessageID_t pMsgId );          //!< return the info value for indicated message
-cdThreadID_t cdmessage_getSenderThread( cdMessageID_t pMsgId ); //!< return the cdThreadID of Thread that has sent the message; if there isn't, or an error happens, return CDTHREADID_ERROR
+sint_t cdmessage_isReaded( cdMessageID_t pMsgId );         //!< checks if this message was readed and returns true, this means that could be only readed or yet deleted; returns false also an error happen
+sint_t cdmessage_isDeleted( cdMessageID_t pMsgId );        //!< check if this message was deleted and return true otherwise return false (also an error happen)
+//cdMsgData_t cdmessage_getData( cdMessageID_t pMsgId );       //!< return the number of logical data attached to message; if there isn't, or an error happens, return 0
+//void* cdmessage_getDataPointer( cdMessageID_t pMsgId ); //!< return pointer to memory where is the data attached to indicated message; if there isn't, or an error happens, return CDMESSAGEDATA_NODATA 
+//cdMsgInfo_t cdmessage_getInfo( cdMessageID_t pMsgId );          //!< return the info value for indicated message
+//cdThreadID_t cdmessage_getSenderThread( cdMessageID_t pMsgId ); //!< return the cdThreadID of Thread that has sent the message; if there isn't, or an error happens, return CDTHREADID_ERROR 
 
 
 //*********************************************************************
 //*************thread *************************************************
 //*********************************************************************
 
-//! function pointer to the thread code, return the exit state (int) and has two param, first is 'first time' boolean (int), second is a cdThreadID of calling thread
-typedef int (*cdtreadFunctionType)(int, cdThreadID_t , int ); //
+//! function pointer to the thread code, return the exit state (sint_t) and has two param, first is 'first time' boolean (sint_t), second is a cdThreadID of calling thread
+typedef sint_t (*cdtreadFunctionType)(sint_t, cdThreadID_t, sint_t); //
 
 //this is struct type to manages thread
 typedef struct cdthreadStruct_tag{
@@ -500,34 +517,35 @@ typedef struct cdthreadStruct_tag{
    int Priority;                //!< 0 means disabled, 1 or more indicates that is enabled and the priority level (higher value-> higher priority) 
    int Wakeup;                  //!< 0 means disabled, 1 = enable thread when MessagesCounter become >0, 2 or more to be defined in the future
    cdtreadFunctionType cdtreadFunction;//!< function pointer to the thread code, return the exit state (int) and has two param, first is 'first time' boolean (int), second is a cdThreadID of calling thread
-   int LastExitState;            //!< indicates the returned value when exiting from *cdtreadFunction; usefull when reenter to know last state.
-   int isTheFirstTime;             //!< boolean, if true indicates that is the first time that the cdtreadFunction is called.
+   sint_t LastExitState;            //!< indicates the returned value when exiting from *cdtreadFunction; usefull when reenter to know last state.
+   sint_t isTheFirstTime;             //!< boolean, if true indicates that is the first time that the cdtreadFunction is called.
    cdMessageID_t MessagesCounter;   //!< indicates the number of messages available for this thread; 0 means no msg. The queue is LIFO type
-   cdMessageID_t FirstMsgID;        //!< msgid of first message; if -1 means no messages
-   cdMessageID_t LastMsgID;         //!< msgid of last available message; if -1 means no messages
-
-}cdthreadStruct;
+   cdMessageID_t FirstMsgID;         //!< msgid of first message; if -1 means no messages 
+   cdMessageID_t LastMsgID;         //!< msgid of last available message; if -1 means no messages 
+   char LogName[4];                 //!< logical name
+} cdThreadStruct_t;
 
 
 
 /*!   \var cdthreadStruct cdthreadsSystemArray
     is the system array that stores the cdthread structure used to manage threads
 */
-extern cdthreadStruct cdthreadsSystemArray[CDTHREAD_MAX_NUM_THREADS];
+extern cdThreadStruct_t cdthreadsSystemArray[CDTHREAD_MAX_NUM_THREADS];
 
 
+#define  CDTHREAD_ALWAYSTHREAD_INDEX   0
 
 
 
 /*!   \var cdThreadID_t LASTCALLEDTHREADIDBYENGINE
     used to inform extern code which is the last executed thread function called by thread_engine
 */
-extern cdThreadID_t LASTCALLEDTHREADIDBYENGINE;
+extern cdThreadID_t LASTCALLEDTHREADIDBYENGINE; 
 
 /*!   \var cdThreadID_t LASTCALLEDTHREADIDBYUSER
     advise external code which is the last called thread by user
 */
-extern cdThreadID_t LASTCALLEDTHREADIDBYUSER;
+extern cdThreadID_t LASTCALLEDTHREADIDBYUSER;   
 
 
 
@@ -542,23 +560,23 @@ extern cdThreadID_t LASTCALLEDTHREADIDBYUSER;
 /*! \def cdthread_isEngineManagedID(x)
    is a macro that check if cdThreadID 'x' is Engine managed cdthread; return true if is Engine managed
 */
-#define cdthread_isEngineManagedID(x)   ( x > CDTHREADID_ERROR)
+#define cdthread_isEngineManagedID( YxY )   ( YxY > CDTHREADID_ERROR)
 
 /*! \def cdthread_isUserManagedID(x)
    is a macro that check if cdThreadID 'x' is user managed cdthread; return true if is user managed
 */
-#define cdthread_isUserManagedID(x)      ( x < CDTHREADID_ERROR)
+#define cdthread_isUserManagedID( YxY )      ( YxY < CDTHREADID_ERROR)
 
 /*! \def cdthread_isErrorID(x)
    is a macro that check if cdThreadID 'x' is no usable cdThreadID (errorID) ; return true if is unusable 
 */
-#define cdthread_isErrorID(x)      ( x == CDTHREADID_ERROR)
+#define cdthread_isErrorID( YxY )      ( YxY == CDTHREADID_ERROR)
 
 /*! \def cdthread_checkValidID(x)
    checks if cdThredID 'x' is a valid ID, this means that isn't a CDTHREADID_ERROR and is inside from -CDTHREAD_MAX_NUM_THREADS to CDTHREAD_MAX_NUM_THREADS.
    \n return true if is valid otherwis return false
 */
-#define cdthread_checkValidID( YY)   (( YY !=CDTHREADID_ERROR)&&( YY <=CDTHREAD_MAX_NUM_THREADS)&&( YY >=(CDTHREAD_MAX_NUM_THREADS*(-1))))
+#define cdthread_checkValidID( YxY)   (( YxY !=CDTHREADID_ERROR)&&( YxY <=CDTHREAD_MAX_NUM_THREADS)&&( YxY >=(CDTHREAD_MAX_NUM_THREADS*(-1))))
 
 
 
@@ -568,7 +586,7 @@ extern cdThreadID_t LASTCALLEDTHREADIDBYUSER;
    used also as parameter in function like cdthread_new() and cdthread_newUserManaged to pass a CDTHREADFUNCTION_NOFUNCTION address for tread function
 */
 //#define CDTHREADFUNCTION_NOFUNCTION      (cdtreadFunctionType)0x00000000
-int CDTHREADFUNCTION_NOFUNCTION(int a, cdThreadID_t b , int c);
+sint_t CDTHREADFUNCTION_NOFUNCTION(sint_t a, cdThreadID_t b , sint_t c);
 
 
 /*! \def CDTHREADPRIORITY_DISABLED
@@ -600,32 +618,42 @@ int CDTHREADFUNCTION_NOFUNCTION(int a, cdThreadID_t b , int c);
 void cdthread_initAll(void); //!< must be called by initialization main to reset and init system threads array
 
 cdThreadID_t cdthread_getFreeID(void);                           //!< searchs free/available position in system thread array
-cdthreadStruct* cdthread_getPointerToStruct(cdThreadID_t pThId); //!< returns a cdthreadStruct type pointer directly to inndicated element of internal thread struct array; in case of error return a pointer to 0x0000000
+cdThreadStruct_t* cdthread_getPointerToStruct(cdThreadID_t pThId); //!< returns a cdthreadStruct type pointer directly to inndicated element of internal thread struct array; in case of error return a pointer to 0x0000000
 cdThreadID_t cdthread_getArrayIdxFromID(cdThreadID_t pThId);      //!< return the index for cdthreadsSystemArray extracted from indicated cdThreadID (pThId)
 
-int  cdthread_new(cdThreadID_t* pThId, cdtreadFunctionType ptrFunction);    //!< creates a new thread for Thread_Engine; after creation the thread is disabled, doesn't have messages and the firsttime is set to true
-int  cdthread_newUserManaged(cdThreadID_t* pThId, cdtreadFunctionType ptrFunction); //!<creates a new USER managed thread (not managed by Thread Engine); after creation the thread is disabled, doesn't have messages and the first time is set to true
+//sint_t cdthread_new(cdThreadID_t* pThId, cdtreadFunctionType ptrFunction);    
+sint_t cdthread_new(cdThreadID_t* pThId, cdtreadFunctionType ptrFunction, const char * pLogName); //!< creates a new thread for Thread_Engine; after creation the thread is disabled, doesn't have messages and the firsttime is set to true
+sint_t cdthread_newAlways(cdThreadID_t* pThId, cdtreadFunctionType ptrFunction, const char * pLogName); //!< creates a new thread for Thread_Engine that run always after every other one; for example: run thread A, followed by always thread, followed by Thread B, followed by thrad Always anbd so on
+//sint_t cdthread_newUserManaged(cdThreadID_t* pThId, cdtreadFunctionType ptrFunction); 
+sint_t cdthread_newUserManaged(cdThreadID_t* pThId, cdtreadFunctionType ptrFunction, const char * pLogName); //!<creates a new USER managed thread (not managed by Thread Engine); after creation the thread is disabled, doesn't have messages and the first time is set to true
 
-int  cdthread_DestroyThread(cdThreadID_t* pThId);                        //!< destroy the indicated thread (memory are free for another new thread), and every message associated at that thread
-int  cdthread_isDestroyed(cdThreadID_t pThId);         //!<checks if passed id is destroyed (invalid pThId or pThId signed as destroyed) and if it is then return true
+sint_t cdthread_DestroyThread(cdThreadID_t* pThId);                        //!< destroy the indicated thread (memory are free for another new thread), and every message associated at that thread
+sint_t cdthread_isDestroyed(cdThreadID_t pThId);         //!<checks if passed id is destroyed (invalid pThId or pThId signed as destroyed) and if it is then return true
 #define cdthread_Exist( pThId )            (!cdthread_isDestroyed( pThId ))   //!<checks if passed id is valid and indicated thread is not destroyed 
 
-int  cdthread_changeFunction(cdThreadID_t pThId, cdtreadFunctionType ptrFunction); //!< changes only called function by indicated thread without change any other thread fields
-int  cdthread_isFunction(cdThreadID_t pThId, cdtreadFunctionType ptrFunction);   //!<checks if called function by indicated thread (pThId) is the same passed (ptrFunction)
-int  cdthread_reassign(cdThreadID_t* pThId, cdtreadFunctionType ptrFunction);    //!<destroys allocated thread and assign a new one
+sint_t cdthread_changeFunction(cdThreadID_t pThId, cdtreadFunctionType ptrFunction); //!< changes only called function by indicated thread without change any other thread fields
+sint_t cdthread_isFunction(cdThreadID_t pThId, cdtreadFunctionType ptrFunction);   //!<checks if called function by indicated thread (pThId) is the same passed (ptrFunction)
+////DEPRECATED 2019-03-10: sint_t  cdthread_reassign(cdThreadID_t* pThId, cdtreadFunctionType ptrFunction);    //!<destroys allocated thread and assign a new one
 
-int  cdthread_signAsFirtsTime(cdThreadID_t pThId);       //!<set firsttime flag as true for indicated thread
-int  cdthread_Enable(cdThreadID_t pThId, int pPriority); //!< enable indicated Thread with indicated priority
-int  cdthread_Disable(cdThreadID_t pThId);                 //!< disable indicated Thread and stop to wait a message for wakeup
-int  cdthread_WaitMessage(cdThreadID_t pThId);   //!<disable indicated Thread and set to wait a message; the thread will be called when a message arrive (wakeup one time) to manage the message, but not enabled
+sint_t cdthread_signAsFirtsTime(cdThreadID_t pThId);       //!<set firsttime flag as true for indicated thread
 
-int  cdthread_isEnabled(cdThreadID_t pThId);          //!< checks if indicated Thread is enabled (priority over 0) and return true if enabled
-int  cdthread_getPriority(cdThreadID_t pThId);          //!< return the actual pripority of thread (0=disable), or -1 for error
-int  cdthread_getPrevExitStatus(cdThreadID_t pThId);  //!< return the last exit state; if hasn't a previous exit state (first time executed) return 0. if an error happen return -1
+sint_t cdthread_Enable(cdThreadID_t pThId); //!< enable indicated Thread with base/standard priority 
+sint_t cdthread_Enable_with_priority(cdThreadID_t pThId, sint_t pPriority); //!< enable indicated Thread with indicated priority 
+sint_t cdthread_ISR_FAST_enable(cdThreadID_t pThId);    //!< used only in managed thread and inside ISR to enable a thread without checks and test but quickly
+    
+sint_t cdthread_Disable(cdThreadID_t pThId);                 //!< disable indicated Thread and stop to wait a message for wakeup
+sint_t cdthread_WaitMessage(cdThreadID_t pThId);   //!<disable indicated Thread and set to wait a message; the thread will be called when a message arrive (wakeup one time) to manage the message, but not enabled
 
-int  cdthread_isThrereMessages(cdThreadID_t pThId);   //!< check if indicated thread has almost a message on the thread message queue
-cdMessageID_t cdthread_getMessage(cdThreadID_t pThId); //!<return the first message (ID) on msg queue of indicated thread (and sign it as readed); if there isn't or an error occours then return CDMESSAGEID_ERROR
-int cdthread_removeMessage(cdThreadID_t pThId);      //!<remove first message from thread msg queue and return true if action has success, otherwise return false
+sint_t cdthread_isEnabled(cdThreadID_t pThId);          //!< checks if indicated Thread is enabled (priority over 0) and return true if enabled 
+sint_t cdthread_isWaitingMessage(cdThreadID_t pThId);   //!< checks if indicated Thread is disabled but waiting a message to wakeup
+
+sint_t cdthread_getPriority(cdThreadID_t pThId);          //!< return the actual pripority of thread (0=disable), or -1 for error
+sint_t cdthread_getPrevExitStatus(cdThreadID_t pThId);  //!< return the last exit state; if hasn't a previous exit state (first time executed) return 0. if an error happen return -1
+
+sint_t cdthread_isThrereMessages(cdThreadID_t pThId);   //!< check if indicated thread has almost a message on the thread message queue
+//cdMessageID_t cdthread_getMessage(cdThreadID_t pThId); //!<return the first message (ID) on msg queue for indicated thread (and ); if there isn't or an error occours then return CDMESSAGEID_ERROR
+cdmessageData_t cdthread_getMessage(cdThreadID_t pThId); //!<return the first message (ID) on msg queue for indicated thread (and ); if there isn't or an error occours then return CDMESSAGEID_ERROR
+//sint_t cdthread_removeMessage(cdThreadID_t pThId);      //!<remove first message from thread msg queue and return true if action has success, otherwise return false
 
 
 //******************************************************************************************************
@@ -634,7 +662,84 @@ sint_t cdthread_Engine(void);   //!< is the engine for thread and must be called
 
 //cdThreadID_t cdthread_ThreadToRun(cdThreadID_t LastRunnedThread);   //!< is called by cdthread_Engine() to determine which is next thread to run
 
-sint_t cdthread_UserCallThreadFunction(cdThreadID_t pThId, int* exitCode); //!< call thread_function, if thread is enabled and id is good (no errors); return true if called, otherwise false
+sint_t cdthread_UserCallThreadFunction(cdThreadID_t pThId, sint_t* exitCode); //!< call thread_function, if thread is enabled and id is good (no errors); return true if called, otherwise false
+
+
+//******************************************************************************************************
+
+//following define used inside a thread to manage functionality
+#define NEW_CDTHFUNCTION( XyX ) 	sint_t XyX (sint_t firstTime, cdThreadID_t ThisThread, sint_t prevExitCode)
+
+//used to split code for a long NEW_CDTHFUNCTION( XXX ), so that inside NEW_CDTHFUNCTION( XXX ) is possible to call a NEW_CDTHSUBFUNCTION( XXX ) by CALL_CDTHSUBFUNCTION( ... )
+#define NEW_CDTHSUBFUNCTION( XyX ) 	sint_t XyX (sint_t firstTime, cdThreadID_t ThisThread, sint_t prevExitCode, void* callerDataPtr)
+#define CALL_CDTHSUBFUNCTION( XyX , XXPtrToDataXX ) 	prevExitCode = XyX (firstTime, ThisThread, prevExitCode, (void*) XXPtrToDataXX  )
+
+//for example NEW_CDTHFUNCTION( BuzzerCDThFunction ) creates:
+//sint_t BuzzerCDThFunction(sint_t firstTime, cdThdID_t ThisThread, sint_t prevExitState)
+
+#define cdTHISth_getThreadID() 			ThisThread
+#define cdTHISth_getPrevExitStatus()    prevExitCode
+#define cdTHISth_getActualStatus()      prevExitCode
+#define cdTHISth_setActualStatus( XyX ) prevExitCode = XyX
+#define cdTHISth_IsFirstTimeThatRun() 	(firstTime == TRUE )
+#define cdTHISth_Destroy() 			    cdthread_DestroyThread( ThisThread )
+#define cdTHISth_signAsFirtsTime() 		cdthread_signAsFirtsTime( ThisThread )
+//not implemented #define cdTHISth_waitUpTo( TTT ) 		cdthread_waitUpTo( ThisThread , TTT )
+#define cdTHISth_Enable() 			    cdthread_Enable( ThisThread , CDTHREADPRIORITY_ENABLED )
+#define cdTHISth_Disable() 			    cdthread_Disable( ThisThread )
+#define cdTHISth_isThrereMessages() 	cdthread_isThrereMessages( ThisThread )
+#define cdTHISth_getMessage() 			cdthread_getMessage( ThisThread )
+#define cdTHISth_removeMessage() 		cdthread_removeMessage( ThisThread )
+#define cdTHISth_waitMessage()          cdthread_WaitMessage( ThisThread )
+
+#define cdTHISth_NewMsgNoData( XXXThreadDest , XXXInfoVal )                          cdmessage_new( XXXThreadDest , XXXInfoVal , CDMESSAGEDATA_NODATA , ThisThread )
+#define cdTHISth_NewMsgWithData( XXXThreadDest , XXXInfoVal , XXXData )              cdmessage_new( XXXThreadDest , XXXInfoVal , XXXData , ThisThread )
+//remenber: data pointed by XXXPtrData must be static or global otherwise the reader will read wrong and unpredictable data
+#define cdTHISth_NewMsgWithPtrToData( XXXThreadDest , XXXInfoVal , XXXPtrData )      cdmessage_new( XXXThreadDest , XXXInfoVal , (cdMsgData_t)((void *)XXXPtrData) , ThisThread )
+
+#define Anonymous_NewMsgNoData( XXXThreadDest , XXXInfoVal )                          cdmessage_new( XXXThreadDest , XXXInfoVal , CDMESSAGEDATA_NODATA , CDTHREADID_NOTHREAD )
+#define Anonymous_NewMsgWithData( XXXThreadDest , XXXInfoVal , XXXData )              cdmessage_new( XXXThreadDest , XXXInfoVal , XXXData , CDTHREADID_NOTHREAD )
+//remenber: data pointed by XXXPtrData must be static or global otherwise the reader will read wrong and unpredictable data
+#define Anonymous_NewMsgWithPtrToData( XXXThreadDest , XXXInfoVal , XXXPtrData )      cdmessage_new( XXXThreadDest , XXXInfoVal , (cdMsgData_t)((void *)XXXPtrData) , CDTHREADID_NOTHREAD )
+
+
+//remenber: data pointed by XXXPtrData must be static or global otherwise the reader will read wrong and unpredictable data
+#define cdTHISth_MsgAnswerToSender( XXXInfoVal )                                     cdmessage_new( msgD.msgSender , XXXInfoVal , CDMESSAGEDATA_NODATA , ThisThread )
+#define cdTHISth_MsgAnswerToSenderWithData( XXXInfoVal , XXXData )                   cdmessage_new( msgD.msgSender , XXXInfoVal , XXXData , ThisThread )
+//remenber: data pointed by XXXPtrData must be static or global otherwise the reader will read wrong and unpredictable data
+#define cdTHISth_MsgAnswerToSenderWithPtrData( XXXInfoVal , XXXPtrData )             cdmessage_new( msgD.msgSender , XXXInfoVal , XXXPtrData , ThisThread )
+
+
+//remember to place ALLOCATE_CDMESSAGE_STD_VARIABLES	to allocate the variables cdMsgID_t actMsg ; sint_t msgInfo ; cdThdID_t msgSender ;  void* msgDataPtr
+//this define simply call and assign value for the cdthread_getMessage and cdmessage_getInfo
+//#define ALLOCATE_ACTMSG_MSGINFO_VARIABLES		cdMessageID_t actMsg ; sint_t msgInfo 
+//#define ALLOCATE_MSG_SENDER_VARIABLE            static cdThreadID_t msgSender = CDTHREADID_NOTHREAD 
+//#define ALLOCATE_MSG_SENDER_DATAPTR_VARIABLES	static cdThreadID_t msgSender = CDTHREADID_NOTHREAD ;  cdMsgData_t msgData
+//#define ALLOCATE_MSG_ALL_VARIABLES              cdMessageID_t actMsg ; sint_t msgInfo ; static cdThreadID_t msgSender = CDTHREADID_NOTHREAD ;  cdMsgData_t msgData 
+#define ALLOCATE_MSG_ALL_VARIABLES                static cdmessageData_t msgD;
+
+//following define used inside a thread to manage messages
+//#define cdTHISth_getActMsgAndMsgInfo()      actMsg = cdthread_getMessage( ThisThread ) ; msgInfo = cdmessage_getInfo( actMsg )
+//#define cdTHISth_getMsgSender()             msgSender = cdmessage_getSenderThread( actMsg )
+//#define cdTHISth_getMsgData()               msgData = cdmessage_getData( actMsg )
+//#define cdTHISth_getMsgDataPointer()		msgData = (cdMsgData_t)cdmessage_getDataPointer( actMsg )
+#define cdTHISth_getActMsgParameters()               msgD = cdthread_getMessage( ThisThread )
+
+
+//#define cdTHISth_useActMsg()                actMsg
+//#define cdTHISth_useMsgInfo()               msgInfo
+//#define cdTHISth_useMsgSender()             msgSender
+//#define cdTHISth_useMsgDataPtr()            (void *)msgData
+//#define cdTHISth_useMsgData()               msgData
+#define cdTHISth_useMsgDstruct()            msgD
+#define cdTHISth_useActMsg()                msgD.actMsg
+#define cdTHISth_useMsgInfo()               msgD.msgInfo
+#define cdTHISth_useMsgSender()             msgD.msgSender
+#define cdTHISth_useMsgDataPtr()            (void *)(msgD.msgData)
+#define cdTHISth_useMsgData()               msgD.msgData
+
+
+//******************************************************************************************************
 
 
 
@@ -646,41 +751,71 @@ sint_t cdthread_UserCallThreadFunction(cdThreadID_t pThId, int* exitCode); //!< 
 //use a 64bit means that if ticks is 1us we have 580000 years before it has a round 
 
 //indicates that 1ms is equal to 100 ticks of Absolute_timer
-#define CDTIMER_us_FOR_TICK   8
-#ifndef CDTIMER_us_FOR_TICK
-    #ERROR CDTIMER_us_FOR_TICK not defined, see CDThread.h
-#endif
+//#define CDTIMER_us_FOR_TICK   8
+//#ifndef CDTIMER_us_FOR_TICK
+//    #error CDTIMER_us_FOR_TICK not defined, see CDThread.h
+//#endif
 
 
 //indicates that 1ms is equal to 100 ticks of Absolute_timer
-//#define CDTIMER_1ms_TICKS   ( 1000 / CDTIMER_us_FOR_TICK )
-#define CDTIMER_1ms_TICKS   125
+////#define CDTIMER_1ms_TICKS   ( 1000 / CDTIMER_us_FOR_TICK )
+//#define CDTIMER_1ms_TICKS   125
 
 //#define CDTIMER_1s_TICKS   ( 1000000 / CDTIMER_us_FOR_TICK )
-#define CDTIMER_1s_TICKS    125000
+//because timer1 use a 32768Hz external crystal, the results is that
+#define CDTIMER_1s_TICKS    32768
 
 //the cdTimerID is not a simple ID but contains the value when timer expires (expeted absolute timer value)
 //with CDTIMER_us_FOR_TICK = 8 the maximun storable time is 34359,7384 seconds that is a little more than 9,5 hours
-typedef uint32_t cdTimerID;
-
+#ifdef PLATFORM_BLACKFIN
+   typedef uint64_t cdTimerID;
+#else
+   typedef uint32_t cdTimerID;
+#endif
 ////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////
 //GLOBAL VARIABLE FOR TIME, see CDTIMER_us_FOR_TICK to know how many us for ticks
 extern  cdTimerID   Absolute_timer;
+extern void Update_Absolute_Timer();   //!< the function used to update Absolute Timer value
+extern void ISR_TIM1_Update_Absolute_Timer() ; //!<special version of update_absolute_timer for ISR of timer1
+//extern  void ForceTim0Value( uint16_t tvalue ); //!< the function used to update timer0 value without tick error in Update_Absolute_Timer
+extern  void Set_Absolute_Timer( cdTimerID pval ); //!< set the value counting of absolute timer avoid errors when is called Update_Absolute_Timer
+#define Get_Absolute_Timer()    (Absolute_timer)
+
+//#define Absolute_Timer_Ticks_to_Seconds( tickXYX )    (tickXYX /  CDTIMER_1s_TICKS)
+#define Absolute_Timer_Ticks_get_Seconds( tickXYX )    (tickXYX >> 15)
+
+//#define Absolute_Timer_Ticks_get_Remainder( tickXYX )    (tickXYX - (((uint32_t)(tickXYX / CDTIMER_1s_TICKS)) * CDTIMER_1s_TICKS))
+#define Absolute_Timer_Ticks_get_Remainder( tickXYX )    (tickXYX & 0x7FFF)
 ////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////
 
-   
-#define cdtimer_setupTicks(ticksVal)    (Absolute_timer + ticksVal)
-#define cdtimer_setup_s(msVal)          (Absolute_timer + (msVal * CDTIMER_1s_TICKS))
-#define cdtimer_setupms(msVal)          (Absolute_timer + (msVal * CDTIMER_1ms_TICKS))
-#define cdtimer_setupus(usVal)          (Absolute_timer + (usVal / CDTIMER_us_FOR_TICK))
-#define cdtimer_isExpired(cdTID)      (cdTID <= Absolute_timer)
-#define cdtimer_isNotExpired(cdTID)      (cdTID > Absolute_timer)
+//returns number of tick necessary for ValXZYX seconds; ValXZYX must be an integer value
+#define cdtimer_TicksForSeconds( ValXZYX )   (( (cdTimerID)ValXZYX * CDTIMER_1s_TICKS ) + ( ValXZYX >>1 ))
+//used to set a elapsed value for a CDTIMER; returns value of ticks for ticksValXZX added to actual value of absolute tiemr
+//Is a good practice call cdtimer_UpdateTicks() function before use this macro
+#define cdtimer_setupTicks( ticksValXZX )    ( Absolute_timer + ticksValXZX )
+//as cdtimer_setupTicks but desired elapsed time value is expressed in seconds and not in ticks
+#define cdtimer_setup_s( msValXZX )          ( Absolute_timer + cdtimer_TicksForSeconds( msValXZX ) )
+//#define cdtimer_setup_ms( msValXZX )          (Absolute_timer + ( msValXZX * CDTIMER_1ms_TICKS))
+//#define cdtimer_setup2_064ms( msValXZX )     ( Absolute_timer + msValXZX )
+//to fastly divide for 2.064 is possible to moltiply for 0,484496 that
+// is possible to aproximate to X * ((1 - 0,03125) /2)= 0.484375 with Err= -0,025%
+// that is (X - (X>>5))>>1
+//as erroe is 1ms minus on 4s; i think that is aceptable, otherwise
+// a more precise calc is (X - (X>>5) + (X>>12)) /2
+//#define cdtimer_setup_ms( msValXZX )     ( Absolute_timer + ((msValXZX - (msValXZX>>5))>>1) )
+#define cdtimer_setup_ms( msValXZX )          (Absolute_timer + ( msValXZX * CDTIMER_1s_TICKS / 1000))
+
+//#define cdtimer_setupus( usValXZX )          (Absolute_timer + (usValXZX / CDTIMER_us_FOR_TICK))
+#define cdtimer_isExpired( cdTIDxzx )        ( (cdTimerID)cdTIDxzx <= (cdTimerID)Absolute_timer )
+#define cdtimer_isNotExpired( cdTIDxzx )     ( (cdTimerID)cdTIDxzx > (cdTimerID)Absolute_timer )
+
+void cdTimer_INIT();
 
 //use example:
 //cdTimerID myTimer1, myTimer2;
-//myTimer1 = cdtimers_setupTicks(20);  //assign the timer value for 200us
+//myTimer1 = cdtimers_setupTicks(20);   //assign the timer value for 200us
 //myTimer2 = cdtimers_setupms(1);      //assign the timer value for 1ms
 
 //while( cdtimer_isNotExpired(myTimer1) ){
@@ -695,29 +830,29 @@ extern  cdTimerID   Absolute_timer;
 //*********************************************************************
 //*************jump table inside cdth_functions************************
 //*********************************************************************
-
-
 //if varaible equl to n then jump to CDTH_EXITandRETURN with same n value
-#define CDTH_JUMPTABLE( variable , n )   if( variable == n ) goto LABEL_JUMP_WAIT##n  
+//#define CDTH_JUMPTABLE( variable , XZX )   if( variable == XZX ) goto LABEL_JUMP_WAIT##XZX  
+#define CDTH_JUMPTO( XZX )   if( prevExitCode == XZX ) goto LABEL_JUMP_WAIT##XZX  
+//deprecated: #define CDTH_FORCESTATE( XZX )   prevExitCode = XZX  //please use instead cdTHISth_setActualStatus()
 
+//exit with n value if condition is true, also return here from a CDTH_JUMPTABLE with same n value; return and test condition
+#define CDTH_COMEHERE_FOR(  n  )   LABEL_JUMP_WAIT##n: 
+//exit with n value if condition is true, also return here from a CDTH_JUMPTABLE with same n value; return and test condition
+#define CDTH_COMEHERE_butEXITif(  n , conditionXZX )   LABEL_JUMP_WAIT##n:  if( conditionXZX ) return n
+//exit with n value if condition is true, also return here from a CDTH_JUMPTABLE with same n value; return and test condition
+#define CDTH_COMEHERE_butCONTINUEif(  n , conditionXZX )   LABEL_JUMP_WAIT##n:  if( ! ( conditionXZX ) ) return n
 
 //exit with XZX value
 #define CDTH_EXITwithCODE(  XZX  )   return XZX
-
-
-//exit with n value if condition is true, also return here from a CDTH_JUMPTABLE with same n value; return and test condition
-#define CDTH_RETURN_HERE(  n  )   LABEL_JUMP_WAIT##n: 
-
-//exit with n value if condition is true, also return here from a CDTH_JUMPTABLE with same n value; return and test condition
-#define CDTH_RETURNbutEXITif(  n , condition )   LABEL_JUMP_WAIT##n:  if( condition ) return n
-
 //exit with actual state of internal ThisThread variable
 #define CDTH_EXIT      return prevExitCode
+//exit with actual state of internal ThisThread variable
+#define CDTH_EXIT_NEXT_CODE     return ( prevExitCode + 1)
 
-//set EXIT CODE code of function bu NOT EXIT NOW
-#define CDTH_SET_EXIT_CODE(  XZX  )   prevExitCode = XZX
+//deprecated CDTH_SET_EXIT_CODE, see cdTHISth_setActualStatus.
+//set EXIT CODE code of function but NOT EXIT NOW
+//#define CDTH_SET_EXIT_CODE(  XZX  )   prevExitCode = XZX
 
 
-
-#endif  //_CDTHREAD_H_
+#endif  //__CDTHREAD_H__
 

--- a/CDTimers_CCS.c
+++ b/CDTimers_CCS.c
@@ -1,0 +1,145 @@
+////////////////////////////////////////////////////////////////////////////
+////        (C) Copyright Dario Cortese                                 ////
+//// This source code may only be used by Dario Cortese licensed users  ////
+//// This source code may only be distributed to Dario Cortese licensed ////
+//// users.  No other use, reproduction  or distribution is permitted   ////
+//// without written permission.                                        ////
+////                                                                    ////
+//// Author: Dario Cortese                                              ////
+//// Client: Mongoose srl (Mariano Cerbone)                             ////
+//// Created on 26/08/2012                                              ////
+//// Modify on 12/05/2018 to be adapted at CCS compiler                 ////
+//// File: cdtimers_CCS.c                                               ////
+//// Description:                                                       ////
+//// THIS FILE HAS ALL IMPLEMENTATION OF FUNCTIONS USED FOR CDTIMERS    ////
+////   MANAGING; TIMERS ARE USED WITH CDTHREAD, AND VICEVERSA           ////        
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef _CDTIMERS_C_
+#define _CDTIMERS_C_
+
+#include "CDThread.h"
+
+//enable this define if you want that will be stored 8 time-stamp in cdtimer_GetTicks
+//#define _CDTIMERS_DEBUG_
+
+cdTimerID Absolute_timer;
+
+#ifdef _CDTIMERS_DEBUG_
+    unsigned int Tim1idx=0;
+    unsigned int8 Tim1Vals[8];
+#endif
+
+
+//typedef union{
+//    unsigned int8 u8;
+//    struct{
+//    int8 TxCKPS:2;       //bits 0-1//0=1:1, 1=1:4, 2=1:16, 3=1:64
+//    int8 TMRxON:1;      //bit 2   //0=off, 1=on
+//    int8 TxOUTPUTS:4;   //bits 3-6//0=1:1, 1=1:2, .... 15=1:16
+//    int8 N_U:1;         //bit 7   //not used
+//    } bitfield;
+//}SFR_TMR246_t;
+
+
+//common variable for update_absolute_timer   
+uint16_t cmn_update_prev_TMR = 0;
+
+//it uses TIM4 and a global variable u32_SysTicks to increments my system timer
+// every one ticks is equal to 1/125KHz= 8us
+//calls almost every 2,048ms
+
+/*! \fn void Update_Absolute_Timer()
+   \author Dario Cortese
+   \date 01-11-2015 modified 08-02-2019
+   \brief this function is called by main loop user, or some interrupts, to update Absolute_timer global variable.
+   Actually it uses TMR1 as time counter, with external 32768Hz quartz and so a timeout/isr every 2 seconds.
+   \n Absolute timer has 131072 seconds as timeout that is 1.517 days, or 1 day and 12 hours 24 minutes 32 seconds
+   \n for the reason that a so limited time isn't a good choice for a project that stay operative for many days that
+ * \n has been created another timer that count only seconds, the UNIXtimer
+   \return none, but update Absolute_timer global variable
+   \warning this function must be redefined on different hardware or implementation
+   \version 1.00
+   \see cdtimer_INIT
+*/
+void Update_Absolute_Timer()
+{
+    uint16_t act_TMR;
+    uint16_t delta;
+
+    act_TMR = get_timer1();
+    delta = act_TMR - cmn_update_prev_TMR; //now is delta ticks
+    cmn_update_prev_TMR = act_TMR;
+    //add delta to global u32_SysTicks
+    Absolute_timer += delta;
+
+#ifdef _CDTIMERS_DEBUG_
+    Tim1Vals[Tim1idx]=act_TMR;
+    Tim1idx++;
+    if (Tim1idx>7)
+        Tim1idx=0;
+#endif
+
+}
+
+
+/*! \fn void ISR_TIM1_Update_Absolute_Timer()
+   \author Dario Cortese
+   \date 16-03-2019 modified 16-03-2019
+   \brief this function is called by ISR TIM1 and is a little bit different from naun loop version
+   In TIM1 could happen that the read value and prev value are equal, but in this case the difference is 2^16 and not 0
+   \return none, but update Absolute_timer global variable
+   \warning this function must be redefined on different hardware or implementation
+   \version 1.00
+   \see cdtimer_INIT
+*/
+void ISR_TIM1_Update_Absolute_Timer() {
+    uint16_t act_TMR;
+    uint16_t delta;
+    
+    act_TMR = get_timer1();
+    if (act_TMR == cmn_update_prev_TMR){
+        //add delta to global u32_SysTicks
+        Absolute_timer += 0x10000 ;
+    }else{
+        delta = act_TMR - cmn_update_prev_TMR; //now is delta ticks
+        //checks if misleading delta could generate eroor in absolute timer calculaction.
+        //effectively could happen that a small delay could generate a difference of one clock
+        // of timer 1 so delta calc result one but in reality i 0x10001
+        //Against previous situation could, correctly, happen that prev_tmr is 0xffff and newer
+        //timer value is 0x0000 or 0x0001; in this case one or two of delta is truthful
+        if ((delta < 3) && (cmn_update_prev_TMR != 0xFFFF)){
+            Absolute_timer += 0x10000 ;
+        }
+        Absolute_timer += delta;
+    }
+    cmn_update_prev_TMR = act_TMR;
+    //add delta to global u32_SysTicks
+}
+
+
+
+
+
+
+/*! \fn void cdtimer_INIT()
+   \author Dario Cortese
+   \date 01-11-2015 modified on 08-02-2019
+   \brief this function is called by main setup to initialize the time counter (one of the timers available in the microcontroller) in polling mode (NO ISR)
+   Actualy it uses TMR4 with prescaler=/64  and PR4=255, so reset happens every ((Fosc/4)/64)/256=2048us wit 32MHz oscillator.
+   \return none
+   \warning this function must be redefined on different hardware or implementation
+   \version 1.00
+   \see cdtimer_GetTicks
+*/
+void cdTimer_INIT(){
+    //intialize timer1 as
+    //#use timer(timer=1,tick=1ms,bits=32,NOISR)
+    Absolute_timer=0;
+    setup_timer_1(T1_SOSC|T1_DIV_BY_1|T1_SYNC);      //2.0 s overflow 
+    disable_interrupts(INT_TIMER1);    //no interrupt, only polling
+}
+
+
+#endif //_CDTIMERS_C_
+

--- a/CD_types.h
+++ b/CD_types.h
@@ -6,9 +6,10 @@
 //// without written permission.                                        ////
 ////                                                                    ////
 //// Author: Dario Cortese                                              ////
-//// Client: myself                                                     ////
+//// Client: Mongoose srl (Mariano Cerbone)                             ////
 //// User: Dario Cortese                                                ////
-//// Created on 26/01/2012  upodated 01/11/2015                         ////
+//// Created on 26/01/2012                                              ////
+//// Modify on 10/02/2019 to be adapted at CCS compiler                 ////
 //// File: CD_types.h                                                   ////
 //// Description:                                                       ////
 ////    This file has the generic variable type, structure definition   ////
@@ -18,15 +19,15 @@
 ////////////////////////////////////////////////////////////////////////////
 
 
-#ifndef _CD_TYPES_H_
-#define _CD_TYPES_H_
+#ifndef __CD_TYPES_H_
+#define __CD_TYPES_H_
 
 #ifdef DOXYGEN
     #define section( YY )
 #endif
 
-//PLEASE INDICATE THE COMPILER
-#define  COMPILER_CCS
+//PLEASE INDICATE THE COMPILER                      
+#define  COMPILER_CCS 
 //#define  COMPILER_MICROCHIP
 //#define COMPILER_VISUALDSP
 
@@ -34,6 +35,11 @@
 //#define PLATFORM_PIC32
 //#define PLATFORM_PIC24
 #define PLATFORM_PICxx
+//#define PLATFORM_AVR
+//#define PLATFORM_BLACKFIN
+                                   
+
+
 
 
 #ifdef PLATFORM_PICxx
@@ -41,17 +47,71 @@
    //#define FALSE  FALSE
    #define NULL   0
    #ifdef COMPILER_CCS
+      #ifndef _STDINT
       typedef unsigned int8   uint8_t;
-      typedef signed int8     sint8_t;
-      typedef unsigned int16  uint16_t;
-      typedef signed int16    sint16_t;
-      typedef unsigned int32  uint32_t;
-      typedef signed int32    sint32_t;
-      typedef float32         float32_t;
-      typedef signed int8     sint_t;
+      typedef unsigned int16   uint16_t;
+      typedef unsigned int32   uint32_t;
+      #endif  //_STDINT    
+      typedef signed int8   sint8_t;
+      typedef signed int16   sint16_t;
+      typedef signed int32   sint32_t;
+      typedef float32   float32_t;
+      typedef signed int8   sint_t;
       typedef unsigned int8   uint_t;
+      typedef int bool;
    #endif //COMPILER_CCS
+   #ifdef COMPILER_MICROCHIP    
+    #include <stdint.h>
+
+      #define TRUE  0xffffffff
+      #define FALSE 0                                                          
+
+      typedef unsigned int8_t   uint_t;
+      typedef unsigned long  uint32_t;
+      typedef signed int8_t   sint_t;
+      typedef signed int8_t   sint8_t;
+      typedef signed int16_t   sint16_t;
+      typedef signed long    sint32_t;
+   #endif
 #endif //PLATFORM_PICxx
+
+
+#ifdef PLATFORM_PIC24
+   #ifdef COMPILER_CCS
+   #endif //COMPILER_CCS
+#endif //PLATFORM_PIC24
+
+#ifdef PLATFORM_PIC32
+#endif //PLATFORM_PIC32
+
+
+#ifdef PLATFORM_BLACKFIN
+   #ifdef COMPILER_VISUALDSP
+      #define TRUE   true
+      #define FALSE  false
+      //#define NULL   NULL
+      //for blackfin bf533 hw supported and managed
+      typedef unsigned char    uint8_t;
+      typedef signed char      sint8_t;
+      typedef unsigned short  uint16_t;
+      typedef signed short      sint16_t;
+      typedef unsigned int    uint32_t;
+      typedef signed int        sint32_t;
+      //typedef unsigned long   uint32_t;
+      //typedef signed long       sint32_t;
+      //for blackfin bf533 sw supported and managed
+      typedef unsigned long long  uint64_t;
+      typedef signed long long    sint64_t;
+      typedef float              float32_t;
+      typedef signed int   sint_t;
+      typedef unsigned int   uint_t;
+      //typedef double            float32_t;
+      //typedef unsigned fract      ufract16_t;
+      //typedef signed fract      sfract16_t;
+      //typedef unsigned long fract   ufract32_t;
+      //typedef signed long fract   sfract32_t;
+   #endif //COMPILER_VISUALDSP
+#endif //PLATFORM_BLACKFIN
 
 
 
@@ -121,6 +181,7 @@ typedef union uniInt32{
    }i8log;      //logical 
    uint8_t i8[4];
 
+#ifndef COMPILER_MICROCHIP
    struct{
       uint32_t bit0:1;
       uint32_t bit1:1;
@@ -155,7 +216,29 @@ typedef union uniInt32{
       uint32_t bit30:1;
       uint32_t bit31:1;
    }bits;
+#endif
 }TuniInt32_t; //end union uniInt32
 
 
-#endif //_CD_TYPES_H_
+#ifdef PLATFORM_BLACKFIN
+   //little-endian bytes ordering
+   typedef union uniInt64{
+      uint64_t i64;
+      struct{
+         uint32_t i32low;
+         uint32_t i32high;   
+      }i32log;      //logical
+      uint32_t i32[2];
+      struct{
+         uint16_t i16lower;
+         uint16_t i16low;
+         uint16_t i16high;   
+         uint16_t i16higher;   
+      }i16log;      //logical
+      uint16_t i16[4];
+      uint8_t i8[8];
+   }TuniInt64_t; //end union uniInt64
+#endif //PLATFORM_BLACKFIN
+
+
+#endif //__CD_TYPES_H_


### PR DESCRIPTION
A new versione of files with bug correction and CCS issues for versions 5.082 and 5.083. In this versione also I've inserted a new functionality that is Thread "Always". This thread, added with cdthread_newAlways, is located at index zero of cdthread array, and is called after every other thread calls. For example the system now call thread 0, followed by thread 1, followed by thread 0, followed by thread 2, ans so on for thread 3,4,5...  
This allows to execute checks and operation that must be done often; remember that exist only one "tread always" so if you call two times  cdthread_newAlways the second call overwrites the first thread set and that thread function will never called